### PR TITLE
fix: handle html in tables

### DIFF
--- a/tests/test_invalid_html.py
+++ b/tests/test_invalid_html.py
@@ -64,7 +64,7 @@ class TestInvalidHTML:
 
         # Test that mixed content is fully escaped for security
         assert "&lt;p&gt;Valid&lt;/p&gt; &lt;invalid&gt;Invalid&lt;/invalid&gt;" in rendered_html, "Mixed content should be escaped"
-        assert "   &lt;p&gt;   Spaced   &lt;/p&gt;   " in rendered_html, "Mixed content with whitespace should be escaped"
+        assert "<p>   Spaced   </p>" in rendered_html, "Whitespace-padded valid HTML should be preserved"
 
         print("✅ Basic HTML handling works correctly")
 
@@ -375,7 +375,7 @@ class TestInvalidHTML:
         print("✅ Basic edge cases handled correctly")
 
         # Test whitespace handling
-        assert "   &lt;p&gt;   Spaced   &lt;/p&gt;   " in rendered_html, "Mixed content with whitespace should be escaped"
+        assert "<p>   Spaced   </p>" in rendered_html, "Whitespace-padded valid HTML should be preserved"
         print("✅ Whitespace handling correct")
 
         # Test case sensitivity
@@ -384,3 +384,48 @@ class TestInvalidHTML:
         print("✅ Case sensitivity handled correctly")
 
         print("✅ All edge cases handled correctly")
+
+    def test_paragraph_with_nested_anchor_and_real_urls(self):
+        """Test <p> tags containing mixed text and <a> with real HTTPS URLs (regression test)."""
+        data = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "dynamicTable",
+                    "attrs": {
+                        "columns": {
+                            "col1": {"visible": True, "order": 1}
+                        },
+                        "content": {
+                            "headers": ["col1"],
+                            "rows": [
+                                # Mixed text + anchor with double-quoted href
+                                ['<p>EUDAMED: <a href="https://webgate.ec.europa.eu/eudamed/landing-page#/">https://webgate.ec.europa.eu/eudamed/landing-page#/</a></p>'],
+                                # Trailing whitespace before closing tag
+                                ['<p>FDA – MAUDE: <a href="https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfmaude/search.cfm">https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfmaude/search.cfm</a> </p>'],
+                                # Double-quoted href with deep URL path
+                                ['<p>BfArM: <a href="https://www.bfarm.de/SiteGlobals/Forms/Suche/Filtersuche_Produktgruppe_Formular.html">https://www.bfarm.de/SiteGlobals/Forms/Suche/Filtersuche_Produktgruppe_Formular.html</a></p>'],
+                                # Plain paragraph (no anchor)
+                                ["<p>The following keywords are searched:</p>"],
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+
+        rendered_html = self.doc.render(data)
+
+        # All should be preserved as valid HTML, not escaped
+        assert '<a href="https://webgate.ec.europa.eu/eudamed/landing-page#/">https://webgate.ec.europa.eu/eudamed/landing-page#/</a>' in rendered_html, \
+            "Anchor with double-quoted HTTPS href inside <p> should be preserved"
+        assert '<a href="https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfmaude/search.cfm">' in rendered_html, \
+            "Anchor with trailing whitespace before </p> should be preserved"
+        assert '<a href="https://www.bfarm.de/SiteGlobals/Forms/Suche/Filtersuche_Produktgruppe_Formular.html">' in rendered_html, \
+            "Anchor with deep URL path should be preserved"
+        assert "<p>The following keywords are searched:</p>" in rendered_html, \
+            "Plain paragraph should be preserved"
+
+        # None should be escaped
+        assert "&lt;p&gt;" not in rendered_html, "Valid <p> tags should not be escaped"
+        assert "&lt;a " not in rendered_html, "Valid <a> tags should not be escaped"

--- a/tiptapy/html_validator.py
+++ b/tiptapy/html_validator.py
@@ -38,12 +38,12 @@ class HTMLValidator:
         'malignmark', 'mover', 'munder', 'munderover', 'mstyle', 'semantics',
         'annotation', 'annotation-xml'
     }
-    
+
     DANGEROUS_TAGS = {
         'script', 'iframe', 'object', 'embed', 'applet', 'basefont', 'bgsound',
         'link', 'meta', 'title', 'style', 'xmp', 'listing', 'plaintext'
     }
-    
+
     DANGEROUS_ATTRIBUTES = {
         'onerror', 'onclick', 'onload', 'onmouseover', 'onfocus', 'onblur',
         'onchange', 'onsubmit', 'onreset', 'onkeydown', 'onkeyup', 'onkeypress',
@@ -53,28 +53,28 @@ class HTMLValidator:
         'ononline', 'onpagehide', 'onpageshow', 'onpopstate', 'onresize',
         'onstorage', 'onunload'
     }
-    
+
     DANGEROUS_PROTOCOLS = {
         'javascript:', 'vbscript:', 'data:text/html', 'data:application/x-javascript',
         'data:application/javascript', 'data:application/ecmascript'
     }
-    
+
     def is_valid_html(self, content: str) -> Tuple[bool, str]:
         """
         Validate HTML content for safety and well-formedness.
-        
+
         Args:
             content: String content to validate
-            
+
         Returns:
             Tuple of (is_valid, reason)
         """
         if '<' not in content or '>' not in content:
             return False, "No HTML tags found"
-            
+
         if self._has_dangerous_content(content):
             return False, "Contains dangerous content"
-            
+
         try:
             soup = BeautifulSoup(content, 'html.parser')
             if not soup.find():  # Handle empty tags like <>
@@ -88,7 +88,7 @@ class HTMLValidator:
             return True, "Valid HTML"
         except Exception as e:
             return False, f"HTML parsing failed: {str(e)}"
-    
+
     def _has_dangerous_content(self, content: str) -> bool:
         """Check for dangerous strings in content."""
         content_lower = content.lower()
@@ -96,17 +96,18 @@ class HTMLValidator:
             if protocol in content_lower:
                 return True
         return False
-    
+
     def _is_well_formed_html(self, soup: BeautifulSoup, original_content: str) -> bool:
         """Check if HTML is well-formed with balanced tags."""
-        # If BeautifulSoup can parse it without errors, it's likely well-formed
-        # Just check basic structure
-        if not original_content.startswith('<'):
+        # Strip whitespace before checking structure — real-world HTML from rich
+        # text editors commonly has leading/trailing newlines or spaces.
+        stripped = original_content.strip()
+        if not stripped.startswith('<'):
             return False
-        if not (original_content.endswith('>') or original_content.endswith('/>')):
+        if not (stripped.endswith('>') or stripped.endswith('/>')):
             return False
         return True
-    
+
     def _has_only_standard_tags(self, soup: BeautifulSoup) -> bool:
         """Check if all tags are standard HTML tags and not dangerous."""
         for tag in soup.find_all():
@@ -116,7 +117,7 @@ class HTMLValidator:
             if tag_name not in self.STANDARD_HTML_TAGS:
                 return False
         return True
-    
+
     def _has_only_safe_attributes(self, soup: BeautifulSoup) -> bool:
         """Check if all attributes are safe."""
         for tag in soup.find_all():
@@ -125,7 +126,7 @@ class HTMLValidator:
                     attr_name_lower = attr_name.lower()
                     if attr_name_lower in self.DANGEROUS_ATTRIBUTES:
                         return False
-                    
+
                     # Check attribute values for dangerous protocols
                     if isinstance(attr_value, str):
                         attr_value_lower = attr_value.lower()


### PR DESCRIPTION
fix parsing html in tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTML content with leading and trailing whitespace. Whitespace-padded HTML elements are now properly preserved rather than being escaped.

* **Tests**
  * Added test coverage for paragraph elements with nested anchors and URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->