### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Repository-wide code owner
+* @akashnairrr


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file to assign a repository-wide code owner.